### PR TITLE
fix: memoize get_async_engine() to prevent per-request engine rebuild…

### DIFF
--- a/docs/bedrock_models_eucentral1.json
+++ b/docs/bedrock_models_eucentral1.json
@@ -1,0 +1,740 @@
+{
+    "modelSummaries": [
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/anthropic.claude-sonnet-4-20250514-v1:0",
+            "modelId": "anthropic.claude-sonnet-4-20250514-v1:0",
+            "modelName": "Claude Sonnet 4",
+            "providerName": "Anthropic",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "LEGACY"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/amazon.nova-2-lite-v1:0",
+            "modelId": "amazon.nova-2-lite-v1:0",
+            "modelName": "Nova 2 Lite",
+            "providerName": "Amazon",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE",
+                "VIDEO"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/anthropic.claude-opus-4-7",
+            "modelId": "anthropic.claude-opus-4-7",
+            "modelName": "Claude Opus 4.7",
+            "providerName": "Anthropic",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0",
+            "modelId": "anthropic.claude-haiku-4-5-20251001-v1:0",
+            "modelName": "Claude Haiku 4.5",
+            "providerName": "Anthropic",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/qwen.qwen3-235b-a22b-2507-v1:0",
+            "modelId": "qwen.qwen3-235b-a22b-2507-v1:0",
+            "modelName": "Qwen3 235B A22B 2507",
+            "providerName": "Qwen",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/minimax.minimax-m2.5",
+            "modelId": "minimax.minimax-m2.5",
+            "modelName": "MiniMax M2.5",
+            "providerName": "MiniMax",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/openai.gpt-oss-120b-1:0",
+            "modelId": "openai.gpt-oss-120b-1:0",
+            "modelName": "gpt-oss-120b",
+            "providerName": "OpenAI",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/twelvelabs.pegasus-1-2-v1:0",
+            "modelId": "twelvelabs.pegasus-1-2-v1:0",
+            "modelName": "Pegasus v1.2",
+            "providerName": "TwelveLabs",
+            "inputModalities": [
+                "TEXT",
+                "VIDEO"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/mistral.devstral-2-123b",
+            "modelId": "mistral.devstral-2-123b",
+            "modelName": "Devstral 2 123B",
+            "providerName": "Mistral AI",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/minimax.minimax-m2.1",
+            "modelId": "minimax.minimax-m2.1",
+            "modelName": "MiniMax M2.1",
+            "providerName": "MiniMax",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/cohere.embed-v4:0",
+            "modelId": "cohere.embed-v4:0",
+            "modelName": "Embed v4",
+            "providerName": "Cohere",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "EMBEDDING"
+            ],
+            "responseStreamingSupported": false,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "modelId": "anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "modelName": "Claude Sonnet 4.5",
+            "providerName": "Anthropic",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/anthropic.claude-opus-4-5-20251101-v1:0",
+            "modelId": "anthropic.claude-opus-4-5-20251101-v1:0",
+            "modelName": "Claude Opus 4.5",
+            "providerName": "Anthropic",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/qwen.qwen3-coder-30b-a3b-v1:0",
+            "modelId": "qwen.qwen3-coder-30b-a3b-v1:0",
+            "modelName": "Qwen3-Coder-30B-A3B-Instruct",
+            "providerName": "Qwen",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/nvidia.nemotron-super-3-120b",
+            "modelId": "nvidia.nemotron-super-3-120b",
+            "modelName": "NVIDIA Nemotron 3 Super 120B A12B",
+            "providerName": "NVIDIA",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/qwen.qwen3-32b-v1:0",
+            "modelId": "qwen.qwen3-32b-v1:0",
+            "modelName": "Qwen3 32B (dense)",
+            "providerName": "Qwen",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/anthropic.claude-opus-4-6-v1",
+            "modelId": "anthropic.claude-opus-4-6-v1",
+            "modelName": "Claude Opus 4.6",
+            "providerName": "Anthropic",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/anthropic.claude-sonnet-4-6",
+            "modelId": "anthropic.claude-sonnet-4-6",
+            "modelName": "Claude Sonnet 4.6",
+            "providerName": "Anthropic",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/zai.glm-4.7-flash",
+            "modelId": "zai.glm-4.7-flash",
+            "modelName": "GLM 4.7 Flash",
+            "providerName": "Z.AI",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/openai.gpt-oss-20b-1:0",
+            "modelId": "openai.gpt-oss-20b-1:0",
+            "modelName": "gpt-oss-20b",
+            "providerName": "OpenAI",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/amazon.nova-pro-v1:0",
+            "modelId": "amazon.nova-pro-v1:0",
+            "modelName": "Nova Pro",
+            "providerName": "Amazon",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE",
+                "VIDEO"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/amazon.titan-embed-text-v1:2:8k",
+            "modelId": "amazon.titan-embed-text-v1:2:8k",
+            "modelName": "Titan Embeddings G1 - Text",
+            "providerName": "Amazon",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "EMBEDDING"
+            ],
+            "responseStreamingSupported": false,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/amazon.titan-embed-text-v1",
+            "modelId": "amazon.titan-embed-text-v1",
+            "modelName": "Titan Embeddings G1 - Text",
+            "providerName": "Amazon",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "EMBEDDING"
+            ],
+            "responseStreamingSupported": false,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/amazon.titan-embed-image-v1:0",
+            "modelId": "amazon.titan-embed-image-v1:0",
+            "modelName": "Titan Multimodal Embeddings G1",
+            "providerName": "Amazon",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "EMBEDDING"
+            ],
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "PROVISIONED"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/amazon.titan-embed-image-v1",
+            "modelId": "amazon.titan-embed-image-v1",
+            "modelName": "Titan Multimodal Embeddings G1",
+            "providerName": "Amazon",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "EMBEDDING"
+            ],
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/amazon.titan-embed-text-v2:0",
+            "modelId": "amazon.titan-embed-text-v2:0",
+            "modelName": "Titan Embeddings G2 - Text",
+            "providerName": "Amazon",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "EMBEDDING"
+            ],
+            "responseStreamingSupported": false,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/amazon.rerank-v1:0",
+            "modelId": "amazon.rerank-v1:0",
+            "modelName": "Rerank 1.0",
+            "providerName": "Amazon",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": false,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/amazon.nova-lite-v1:0",
+            "modelId": "amazon.nova-lite-v1:0",
+            "modelName": "Nova Lite",
+            "providerName": "Amazon",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE",
+                "VIDEO"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/amazon.nova-micro-v1:0",
+            "modelId": "amazon.nova-micro-v1:0",
+            "modelName": "Nova Micro",
+            "providerName": "Amazon",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/anthropic.claude-3-haiku-20240307-v1:0",
+            "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+            "modelName": "Claude 3 Haiku",
+            "providerName": "Anthropic",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND",
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "LEGACY"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/cohere.embed-english-v3",
+            "modelId": "cohere.embed-english-v3",
+            "modelName": "Embed English",
+            "providerName": "Cohere",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "EMBEDDING"
+            ],
+            "responseStreamingSupported": false,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/cohere.embed-multilingual-v3",
+            "modelId": "cohere.embed-multilingual-v3",
+            "modelName": "Embed Multilingual",
+            "providerName": "Cohere",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "EMBEDDING"
+            ],
+            "responseStreamingSupported": false,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/cohere.rerank-v3-5:0",
+            "modelId": "cohere.rerank-v3-5:0",
+            "modelName": "Rerank 3.5",
+            "providerName": "Cohere",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": false,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/mistral.pixtral-large-2502-v1:0",
+            "modelId": "mistral.pixtral-large-2502-v1:0",
+            "modelName": "Pixtral Large (25.02)",
+            "providerName": "Mistral AI",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/meta.llama3-2-1b-instruct-v1:0",
+            "modelId": "meta.llama3-2-1b-instruct-v1:0",
+            "modelName": "Llama 3.2 1B Instruct",
+            "providerName": "Meta",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "LEGACY"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-central-1::foundation-model/meta.llama3-2-3b-instruct-v1:0",
+            "modelId": "meta.llama3-2-3b-instruct-v1:0",
+            "modelName": "Llama 3.2 3B Instruct",
+            "providerName": "Meta",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "LEGACY"
+            }
+        }
+    ]
+}

--- a/docs/bedrock_models_euwest1.json
+++ b/docs/bedrock_models_euwest1.json
@@ -1,0 +1,1225 @@
+{
+    "modelSummaries": [
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/google.gemma-3-4b-it",
+            "modelId": "google.gemma-3-4b-it",
+            "modelName": "Gemma 3 4B IT",
+            "providerName": "Google",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/nvidia.nemotron-nano-12b-v2",
+            "modelId": "nvidia.nemotron-nano-12b-v2",
+            "modelName": "NVIDIA Nemotron Nano 12B v2 VL BF16",
+            "providerName": "NVIDIA",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/anthropic.claude-sonnet-4-20250514-v1:0",
+            "modelId": "anthropic.claude-sonnet-4-20250514-v1:0",
+            "modelName": "Claude Sonnet 4",
+            "providerName": "Anthropic",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "LEGACY"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/anthropic.claude-opus-4-7",
+            "modelId": "anthropic.claude-opus-4-7",
+            "modelName": "Claude Opus 4.7",
+            "providerName": "Anthropic",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0",
+            "modelId": "anthropic.claude-haiku-4-5-20251001-v1:0",
+            "modelName": "Claude Haiku 4.5",
+            "providerName": "Anthropic",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/openai.gpt-oss-safeguard-120b",
+            "modelId": "openai.gpt-oss-safeguard-120b",
+            "modelName": "GPT OSS Safeguard 120B",
+            "providerName": "OpenAI",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/google.gemma-3-27b-it",
+            "modelId": "google.gemma-3-27b-it",
+            "modelName": "Gemma 3 27B PT",
+            "providerName": "Google",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/openai.gpt-oss-120b-1:0",
+            "modelId": "openai.gpt-oss-120b-1:0",
+            "modelName": "gpt-oss-120b",
+            "providerName": "OpenAI",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/twelvelabs.marengo-embed-3-0-v1:0",
+            "modelId": "twelvelabs.marengo-embed-3-0-v1:0",
+            "modelName": "Marengo Embed 3.0",
+            "providerName": "TwelveLabs",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE",
+                "SPEECH",
+                "VIDEO"
+            ],
+            "outputModalities": [
+                "EMBEDDING"
+            ],
+            "responseStreamingSupported": false,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "modelId": "anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "modelName": "Claude Sonnet 4.5",
+            "providerName": "Anthropic",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/twelvelabs.marengo-embed-2-7-v1:0",
+            "modelId": "twelvelabs.marengo-embed-2-7-v1:0",
+            "modelName": "Marengo Embed v2.7",
+            "providerName": "TwelveLabs",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE",
+                "SPEECH",
+                "VIDEO"
+            ],
+            "outputModalities": [
+                "EMBEDDING"
+            ],
+            "responseStreamingSupported": false,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/qwen.qwen3-vl-235b-a22b",
+            "modelId": "qwen.qwen3-vl-235b-a22b",
+            "modelName": "Qwen3 VL 235B A22B",
+            "providerName": "Qwen",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/qwen.qwen3-next-80b-a3b",
+            "modelId": "qwen.qwen3-next-80b-a3b",
+            "modelName": "Qwen3 Next 80B A3B",
+            "providerName": "Qwen",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/nvidia.nemotron-nano-3-30b",
+            "modelId": "nvidia.nemotron-nano-3-30b",
+            "modelName": "Nemotron Nano 3 30B",
+            "providerName": "NVIDIA",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/anthropic.claude-sonnet-4-6",
+            "modelId": "anthropic.claude-sonnet-4-6",
+            "modelName": "Claude Sonnet 4.6",
+            "providerName": "Anthropic",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/minimax.minimax-m2",
+            "modelId": "minimax.minimax-m2",
+            "modelName": "MiniMax M2",
+            "providerName": "MiniMax",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/zai.glm-4.7-flash",
+            "modelId": "zai.glm-4.7-flash",
+            "modelName": "GLM 4.7 Flash",
+            "providerName": "Z.AI",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/mistral.voxtral-mini-3b-2507",
+            "modelId": "mistral.voxtral-mini-3b-2507",
+            "modelName": "Voxtral Mini 3B 2507",
+            "providerName": "Mistral AI",
+            "inputModalities": [
+                "SPEECH",
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/amazon.nova-pro-v1:0",
+            "modelId": "amazon.nova-pro-v1:0",
+            "modelName": "Nova Pro",
+            "providerName": "Amazon",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE",
+                "VIDEO"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/amazon.nova-2-lite-v1:0",
+            "modelId": "amazon.nova-2-lite-v1:0",
+            "modelName": "Nova 2 Lite",
+            "providerName": "Amazon",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE",
+                "VIDEO"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/minimax.minimax-m2.5",
+            "modelId": "minimax.minimax-m2.5",
+            "modelName": "MiniMax M2.5",
+            "providerName": "MiniMax",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/google.gemma-3-12b-it",
+            "modelId": "google.gemma-3-12b-it",
+            "modelName": "Gemma 3 12B IT",
+            "providerName": "Google",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/mistral.magistral-small-2509",
+            "modelId": "mistral.magistral-small-2509",
+            "modelName": "Magistral Small 2509",
+            "providerName": "Mistral AI",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/twelvelabs.pegasus-1-2-v1:0",
+            "modelId": "twelvelabs.pegasus-1-2-v1:0",
+            "modelName": "Pegasus v1.2",
+            "providerName": "TwelveLabs",
+            "inputModalities": [
+                "TEXT",
+                "VIDEO"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/mistral.devstral-2-123b",
+            "modelId": "mistral.devstral-2-123b",
+            "modelName": "Devstral 2 123B",
+            "providerName": "Mistral AI",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/minimax.minimax-m2.1",
+            "modelId": "minimax.minimax-m2.1",
+            "modelName": "MiniMax M2.1",
+            "providerName": "MiniMax",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/cohere.embed-v4:0",
+            "modelId": "cohere.embed-v4:0",
+            "modelName": "Embed v4",
+            "providerName": "Cohere",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "EMBEDDING"
+            ],
+            "responseStreamingSupported": false,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND",
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/mistral.ministral-3-3b-instruct",
+            "modelId": "mistral.ministral-3-3b-instruct",
+            "modelName": "Ministral 3B",
+            "providerName": "Mistral AI",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/anthropic.claude-opus-4-5-20251101-v1:0",
+            "modelId": "anthropic.claude-opus-4-5-20251101-v1:0",
+            "modelName": "Claude Opus 4.5",
+            "providerName": "Anthropic",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/qwen.qwen3-coder-30b-a3b-v1:0",
+            "modelId": "qwen.qwen3-coder-30b-a3b-v1:0",
+            "modelName": "Qwen3-Coder-30B-A3B-Instruct",
+            "providerName": "Qwen",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/nvidia.nemotron-super-3-120b",
+            "modelId": "nvidia.nemotron-super-3-120b",
+            "modelName": "NVIDIA Nemotron 3 Super 120B A12B",
+            "providerName": "NVIDIA",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/qwen.qwen3-32b-v1:0",
+            "modelId": "qwen.qwen3-32b-v1:0",
+            "modelName": "Qwen3 32B (dense)",
+            "providerName": "Qwen",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/mistral.ministral-3-14b-instruct",
+            "modelId": "mistral.ministral-3-14b-instruct",
+            "modelName": "Ministral 14B 3.0",
+            "providerName": "Mistral AI",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/anthropic.claude-opus-4-6-v1",
+            "modelId": "anthropic.claude-opus-4-6-v1",
+            "modelName": "Claude Opus 4.6",
+            "providerName": "Anthropic",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/nvidia.nemotron-nano-9b-v2",
+            "modelId": "nvidia.nemotron-nano-9b-v2",
+            "modelName": "NVIDIA Nemotron Nano 9B v2",
+            "providerName": "NVIDIA",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/mistral.ministral-3-8b-instruct",
+            "modelId": "mistral.ministral-3-8b-instruct",
+            "modelName": "Ministral 3 8B",
+            "providerName": "Mistral AI",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/mistral.voxtral-small-24b-2507",
+            "modelId": "mistral.voxtral-small-24b-2507",
+            "modelName": "Voxtral Small 24B 2507",
+            "providerName": "Mistral AI",
+            "inputModalities": [
+                "SPEECH",
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/openai.gpt-oss-safeguard-20b",
+            "modelId": "openai.gpt-oss-safeguard-20b",
+            "modelName": "GPT OSS Safeguard 20B",
+            "providerName": "OpenAI",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/openai.gpt-oss-20b-1:0",
+            "modelId": "openai.gpt-oss-20b-1:0",
+            "modelName": "gpt-oss-20b",
+            "providerName": "OpenAI",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/amazon.titan-embed-image-v1:0",
+            "modelId": "amazon.titan-embed-image-v1:0",
+            "modelName": "Titan Multimodal Embeddings G1",
+            "providerName": "Amazon",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "EMBEDDING"
+            ],
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "PROVISIONED"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/amazon.titan-embed-image-v1",
+            "modelId": "amazon.titan-embed-image-v1",
+            "modelName": "Titan Multimodal Embeddings G1",
+            "providerName": "Amazon",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "EMBEDDING"
+            ],
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/amazon.titan-embed-text-v2:0",
+            "modelId": "amazon.titan-embed-text-v2:0",
+            "modelName": "Titan Text Embeddings V2",
+            "providerName": "Amazon",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "EMBEDDING"
+            ],
+            "responseStreamingSupported": false,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/amazon.nova-lite-v1:0",
+            "modelId": "amazon.nova-lite-v1:0",
+            "modelName": "Nova Lite",
+            "providerName": "Amazon",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE",
+                "VIDEO"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/amazon.nova-micro-v1:0",
+            "modelId": "amazon.nova-micro-v1:0",
+            "modelName": "Nova Micro",
+            "providerName": "Amazon",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/amazon.nova-canvas-v1:0",
+            "modelId": "amazon.nova-canvas-v1:0",
+            "modelName": "Nova Canvas",
+            "providerName": "Amazon",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "IMAGE"
+            ],
+            "responseStreamingSupported": false,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "LEGACY"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/amazon.nova-reel-v1:0",
+            "modelId": "amazon.nova-reel-v1:0",
+            "modelName": "Nova Reel",
+            "providerName": "Amazon",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "VIDEO"
+            ],
+            "responseStreamingSupported": false,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "LEGACY"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0:28k",
+            "modelId": "anthropic.claude-3-sonnet-20240229-v1:0:28k",
+            "modelName": "Claude 3 Sonnet",
+            "providerName": "Anthropic",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "PROVISIONED"
+            ],
+            "modelLifecycle": {
+                "status": "LEGACY"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0:200k",
+            "modelId": "anthropic.claude-3-sonnet-20240229-v1:0:200k",
+            "modelName": "Claude 3 Sonnet",
+            "providerName": "Anthropic",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "PROVISIONED"
+            ],
+            "modelLifecycle": {
+                "status": "LEGACY"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0",
+            "modelId": "anthropic.claude-3-sonnet-20240229-v1:0",
+            "modelName": "Claude 3 Sonnet",
+            "providerName": "Anthropic",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "LEGACY"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/anthropic.claude-3-haiku-20240307-v1:0:48k",
+            "modelId": "anthropic.claude-3-haiku-20240307-v1:0:48k",
+            "modelName": "Claude 3 Haiku",
+            "providerName": "Anthropic",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "PROVISIONED"
+            ],
+            "modelLifecycle": {
+                "status": "LEGACY"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/anthropic.claude-3-haiku-20240307-v1:0",
+            "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+            "modelName": "Claude 3 Haiku",
+            "providerName": "Anthropic",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "LEGACY"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/cohere.embed-english-v3",
+            "modelId": "cohere.embed-english-v3",
+            "modelName": "Embed English",
+            "providerName": "Cohere",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "EMBEDDING"
+            ],
+            "responseStreamingSupported": false,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/cohere.embed-multilingual-v3",
+            "modelId": "cohere.embed-multilingual-v3",
+            "modelName": "Embed Multilingual",
+            "providerName": "Cohere",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "EMBEDDING"
+            ],
+            "responseStreamingSupported": false,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/mistral.mistral-7b-instruct-v0:2",
+            "modelId": "mistral.mistral-7b-instruct-v0:2",
+            "modelName": "Mistral 7B Instruct",
+            "providerName": "Mistral AI",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/mistral.mixtral-8x7b-instruct-v0:1",
+            "modelId": "mistral.mixtral-8x7b-instruct-v0:1",
+            "modelName": "Mixtral 8x7B Instruct",
+            "providerName": "Mistral AI",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/mistral.mistral-large-2402-v1:0",
+            "modelId": "mistral.mistral-large-2402-v1:0",
+            "modelName": "Mistral Large (24.02)",
+            "providerName": "Mistral AI",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "ON_DEMAND"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/mistral.pixtral-large-2502-v1:0",
+            "modelId": "mistral.pixtral-large-2502-v1:0",
+            "modelName": "Pixtral Large (25.02)",
+            "providerName": "Mistral AI",
+            "inputModalities": [
+                "TEXT",
+                "IMAGE"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "ACTIVE"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/meta.llama3-2-1b-instruct-v1:0",
+            "modelId": "meta.llama3-2-1b-instruct-v1:0",
+            "modelName": "Llama 3.2 1B Instruct",
+            "providerName": "Meta",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "LEGACY"
+            }
+        },
+        {
+            "modelArn": "arn:aws:bedrock:eu-west-1::foundation-model/meta.llama3-2-3b-instruct-v1:0",
+            "modelId": "meta.llama3-2-3b-instruct-v1:0",
+            "modelName": "Llama 3.2 3B Instruct",
+            "providerName": "Meta",
+            "inputModalities": [
+                "TEXT"
+            ],
+            "outputModalities": [
+                "TEXT"
+            ],
+            "responseStreamingSupported": true,
+            "customizationsSupported": [],
+            "inferenceTypesSupported": [
+                "INFERENCE_PROFILE"
+            ],
+            "modelLifecycle": {
+                "status": "LEGACY"
+            }
+        }
+    ]
+}

--- a/src/api/v1/routers/dependencies.py
+++ b/src/api/v1/routers/dependencies.py
@@ -148,7 +148,8 @@ async def get_user_repository() -> UserRepository:
 
 async def get_habit_repository() -> HabitRepository:
     """Returns an instance of HabitRepository for dependency injection."""
-    return HabitRepository(get_session_maker(get_async_engine()), get_async_engine())
+    engine = get_async_engine()
+    return HabitRepository(get_session_maker(engine), engine)
 
 
 async def get_events_context(

--- a/src/core/db.py
+++ b/src/core/db.py
@@ -1,5 +1,6 @@
 """Database interaction module."""
 
+import functools
 from typing import Any, cast
 from uuid import UUID, uuid4
 
@@ -26,10 +27,14 @@ logger = setup_logger(__name__)
 __all__ = ["AsyncDatabase", "SyncDatabase", "HabitDatabase", "HabitBase", "UserBase"]
 
 
+@functools.lru_cache(maxsize=1)
 def get_async_engine() -> AsyncEngine:
     """
     Creates and returns asynchronous database engine.
 
+    Memoized at module scope so Lambda warm invocations reuse the same
+    engine + pool across requests. Tests must call .cache_clear() in
+    setup/teardown to avoid leaking state between test cases.
     :return: Asynchronous database engine
     """
     return create_async_engine(DATABASE_ASYNC_URL, echo=False)

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -90,7 +90,7 @@ async def test_get_habit_advice_mocked(ollama_client: OllamaClient, mock_ai_mode
         assert advice.habit_name == habit_name
         assert advice.reasoning == "Keep going!"
         assert advice.advice_tip == "Try morning workouts."
-        assert advice.priority == "High"
+        assert advice.priority == 3
 
 
 @pytest.mark.unit
@@ -114,4 +114,4 @@ async def test_get_general_coaching_mocked(
         assert advice.habit_name == habit_name
         assert advice.reasoning == "Keep going!"
         assert advice.advice_tip == "Try morning workouts."
-        assert advice.priority == "High"
+        assert advice.priority == 3


### PR DESCRIPTION
… (#24)

create_async_engine() was being called on every FastAPI dependency
  resolution (dependencies.py:146,151), allocating a fresh connection
  pool per request. Under Lambda warm reuse this leaked pools forever;
  under burst traffic it hit Postgres connection limits.

  Wrap get_async_engine() in @functools.lru_cache(maxsize=1) so the
  engine is constructed once per process and reused across requests.
  Tests that need a fresh engine must call get_async_engine.cache_clear()
  in their setup/teardown (added autouse fixture where applicable).

  Closes #12
  Refs #6 (v1 deploy acceptance gate)