### PR TITLE
Fix/lambda deploy blockers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
                 labels: ${{ steps.meta.outputs.labels }}
 
             - name: Run Trivy vulnerability scanner
-              uses: aquasecurity/trivy-action@0.33.1
+              uses: aquasecurity/trivy-action@0.36
               with:
                 image-ref: ${{ steps.meta.outputs.tags }}
                 format: 'table'

--- a/conftest.py
+++ b/conftest.py
@@ -61,6 +61,16 @@ def pytest_configure(config: Any) -> None:
     config.addinivalue_line("markers", "integration: Integration tests with real DB")
 
 
+INTEGRATION_FIXTURES = {"postgres_container", "redis_container", "postgres_db_objects", "redis_instance"}
+
+
+def pytest_collection_modifyitems(config: Any, items: Any) -> None:
+    """Pytest hook to modify collected test items based on markers and fixture usage"""
+    for item in items:
+        if INTEGRATION_FIXTURES & set(getattr(item, "fixturenames", ())):
+            item.add_marker(pytest.mark.integration)
+
+
 # ==================== SHARED FIXTURES ====================
 
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -35,7 +35,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[Any, Any]:
             daemon_address="xray-daemon:2000",
             context_missing="LOG_ERROR",
         )
-        patch(["requests", "botocore"])
+        patch(["requests", "asyncpg"])
     yield
     await cache.close()
     logger.info("Redis connection closed")

--- a/src/api/middleware.py
+++ b/src/api/middleware.py
@@ -66,34 +66,36 @@ class CustomXrayMiddleware:
 
         request = Request(scope)
         method = request.method
-        segment = xray_recorder.begin_segment(
+        subsegment = xray_recorder.begin_subsegment(
             name=f"{method} {path}",
-            sampling=1,
         )
-
-        segment.put_http_meta("url", str(request.url))
-        segment.put_http_meta("method", method)
+        if subsegment:
+            subsegment.put_http_meta("url", str(request.url))
+            subsegment.put_http_meta("method", method)
 
         async def send_wrapper(message: MutableMapping[str, Any]) -> None:
             """"""
             if message["type"] == "http.response.start":
                 status = message.get("status", 200)
-                segment.put_http_meta("status", status)
+                if subsegment:
+                    subsegment.put_http_meta("status", status)
                 headers = list(message.get("headers", []))
-                headers.append(
-                    (b"x-amzn-trace-id", f"Root={segment.trace_id}".encode()),
-                )
+                if subsegment:
+                    headers.append(
+                        (b"x-amzn-trace-id", f"Root={subsegment.trace_id}".encode()),
+                    )
                 message["headers"] = headers
             await send(message)
 
         try:
             await self.app(scope, receive, send_wrapper)
         except Exception as err:
-            segment.add_exception(err, getattr(err, "__traceback__", None))
+            if subsegment:
+                subsegment.add_exception(err, getattr(err, "__traceback__", None))
             logger.exception("Error processing request in X-Ray middleware", error=str(err))
             raise
         finally:
-            xray_recorder.end_segment()
+            xray_recorder.end_subsegment()
 
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -90,7 +90,7 @@ async def test_get_habit_advice_mocked(ollama_client: OllamaClient, mock_ai_mode
         assert advice.habit_name == habit_name
         assert advice.reasoning == "Keep going!"
         assert advice.advice_tip == "Try morning workouts."
-        assert advice.priority == "High"
+        assert advice.priority == 3
 
 
 @pytest.mark.unit
@@ -114,4 +114,4 @@ async def test_get_general_coaching_mocked(
         assert advice.habit_name == habit_name
         assert advice.reasoning == "Keep going!"
         assert advice.advice_tip == "Try morning workouts."
-        assert advice.priority == "High"
+        assert advice.priority == 3


### PR DESCRIPTION
## Summary

Three independent Lambda deploy blockers, plus a test fix and CI bump.

### X-Ray integration (`src/api/main.py`, `src/api/middleware.py`)
- **main.py**: Patch `asyncpg` instead of `botocore` so DB calls become X-Ray subsegments. Botocore patching was a copy-paste leftover from a non-existent AWS SDK code path.
- **middleware.py**: Switch from `begin_segment`/`end_segment` to `begin_subsegment`/`end_subsegment` with null guards. Under Lambda the runtime owns the root segment — calling
`begin_segment` ourselves either crashed or produced orphan segments. Subsegments nest correctly under the Lambda-managed root.

### Test collection (`conftest.py`)
- Add `pytest_collection_modifyitems` hook that auto-applies `@pytest.mark.integration` to any test pulling in a testcontainer fixture (`postgres_container`, `redis_container`,
`postgres_db_objects`, `redis_instance`).
- Lets `pytest -m "not integration"` cleanly skip ~61 container tests in environments without Docker (CI fast path, local dev without daemon).

### Test fix (`tests/test_ollama_client.py`)
- Update two assertions: `advice.priority == "High"` → `advice.priority == 3`. Schema changed priority to int; tests were stale.

### CI (`.github/workflows/ci.yml`)
- Bump `aquasecurity/trivy-action` from `0.33.1` to `0.36`.

## Test plan
- [x] `pytest -m "not integration"` runs without Docker and skips container tests cleanly
- [ ] `pytest -m integration` still runs full suite when Docker is up

Closes #14, Closes #15
Refs #3 (sync Mangum dispatch decision)