### PR TITLE
feat(coach): AI Coach v1 — Bedrock invoke + /coach/chat + Pydantic schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ strips
 # MD files
 aws-deploy-debrief-2026-05-15.md
 aws_impl_verification_log_12_05_26.md
+
+# Local mentor instructions (never commit)
+CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,7 @@ packaged-template.yaml
 # Stray shell-redirect artifacts
 passes
 strips
+
+# MD files
+aws-deploy-debrief-2026-05-15.md
+aws_impl_verification_log_12_05_26.md

--- a/config.py
+++ b/config.py
@@ -45,7 +45,9 @@ class Settings(BaseSettings):
     AWS_SES_SENDER_EMAIL: str = "test@example.com"
     AWS_ACCESS_KEY_ID: str | None = None
     AWS_SECRET_ACCESS_KEY: str | None = None
-    XRAY_ENABLED: bool = False
+    AWS_XRAY_ENABLED: bool = False
+    AWS_BEDROCK_LLM_MODEL_ID: str = "eu.anthropic.claude-haiku-4-5-20251001-v1:0"
+    AWS_BEDROCK_API_KEY: str | None = None
 
     # AI/LLM
     OLLAMA_URL: str = "http://localhost:11434"

--- a/conftest.py
+++ b/conftest.py
@@ -34,7 +34,7 @@ from src.api.v1.routers.dependencies import (
     get_user_manager,
     require_admin,
 )
-from src.core.ai_service import AIService
+from src.core.ai_service import HabitContextService
 from src.core.cache import RedisManager
 from src.core.db import AsyncDatabase, SyncDatabase
 from src.core.events.events import HabitCompletedEvent
@@ -746,18 +746,18 @@ async def habit_completed_event_factory() -> "Callable[[int], HabitCompletedEven
 
 
 @pytest_asyncio.fixture(scope="function")
-async def ai_service() -> AIService:
-    """Create an AIService instance with mocked repositories."""
-    return AIService(user_repo=AsyncMock(), habit_repo=AsyncMock())
+async def ai_service() -> HabitContextService:
+    """Create an HabitContextService instance with mocked repositories."""
+    return HabitContextService(user_repo=AsyncMock(), habit_repo=AsyncMock())
 
 
 @pytest_asyncio.fixture
-async def ai_service_factory() -> Callable[[], AIService]:
+async def ai_service_factory() -> Callable[[], HabitContextService]:
     """
-    Create an AIService instance with mocked repositories and return a factory for it.
+    Create an HabitContextService instance with mocked repositories and return a factory for it.
     """
 
-    def _ai_service_factory() -> AIService:
-        return AIService(user_repo=AsyncMock(), habit_repo=AsyncMock())
+    def _ai_service_factory() -> HabitContextService:
+        return HabitContextService(user_repo=AsyncMock(), habit_repo=AsyncMock())
 
     return _ai_service_factory

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -70,7 +70,7 @@ services:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - OLLAMA_URL=${OLLAMA_URL}
-      - XRAY_ENABLED=true
+      - AWS_XRAY_ENABLED=true
     ports:
       - "8000:8000"
     volumes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "structlog>=25.5.0",
     "aws-xray-sdk[asgi]>=2.15.0",
     "mangum>=0.21.0",
+    "types-aiobotocore-bedrock>=3.7.0",
 ]
 
 [dependency-groups]

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -10,7 +10,7 @@ from sqlalchemy import text
 
 from config import settings
 from src.api.middleware import CustomXrayMiddleware, LoggingMiddleware, SecurityHeadersMiddleware
-from src.api.v1.routers import admin, ai, habits, reports, security, users
+from src.api.v1.routers import admin, coach, habit_advice, habits, reports, security, users
 from src.core.cache import RedisManager
 from src.core.db import get_async_engine
 from src.core.exception_handlers import register_exception_handlers
@@ -35,7 +35,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[Any, Any]:
             daemon_address="xray-daemon:2000",
             context_missing="LOG_ERROR",
         )
-        patch(["requests", "asyncpg"])
+        patch(["requests"])
     yield
     await cache.close()
     logger.info("Redis connection closed")
@@ -46,8 +46,9 @@ app.include_router(habits.router)
 app.include_router(users.router)
 app.include_router(admin.router)
 app.include_router(security.router)
-app.include_router(ai.router)
+app.include_router(habit_advice.router)
 app.include_router(reports.router)
+app.include_router(coach.router)
 app.add_middleware(SecurityHeadersMiddleware)
 app.add_middleware(CustomXrayMiddleware)
 app.add_middleware(LoggingMiddleware)

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -15,6 +15,7 @@ from src.core.cache import RedisManager
 from src.core.db import get_async_engine
 from src.core.exception_handlers import register_exception_handlers
 from src.core.habit_async import AsyncUserManager
+from src.infrastructure.ai.ai_coach import AICoachService
 from src.utils.logger import setup_logger
 
 logger = setup_logger(__name__)
@@ -26,10 +27,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[Any, Any]:
     user_manager = AsyncUserManager()
     await user_manager.service.async_db.async_engine.dispose()
     cache = RedisManager()
+    ai_coach_service = AICoachService()
     await cache.initialize(settings.REDIS_URL)
     app.state.redis_manager = cache
-    logger.info(f"XRAY_ENABLED: {settings.XRAY_ENABLED}")
-    if settings.XRAY_ENABLED:
+    app.state.ai_coach_service = ai_coach_service
+    logger.info(f"AWS_XRAY_ENABLED: {settings.AWS_XRAY_ENABLED}")
+    if settings.AWS_XRAY_ENABLED:
         xray_recorder.configure(
             service="habit-tracker-api",
             daemon_address="xray-daemon:2000",

--- a/src/api/v1/routers/coach.py
+++ b/src/api/v1/routers/coach.py
@@ -1,0 +1,23 @@
+"""
+Conversational AI coach (Bedrock Haiku-backed, stateful chat via conversation_id).
+For habit-AI advice see ai.py."""
+
+from uuid import uuid4
+
+from fastapi import APIRouter
+
+from config import settings
+from src.core.schemas import CoachReply, CoachRequest, CoachResponse
+
+router = APIRouter(prefix=f"{settings.API_V1_STR}/coach", tags=["coach", "chat"])
+
+
+@router.post("/chat")
+async def chat(request: CoachRequest) -> CoachResponse:
+    """Endpoint for conversational AI coaching interactions."""
+    return CoachResponse(
+        reply=CoachReply(reasoning="LLM reasoning", intent="advice", reply="LLM reply", next_action="none"),
+        conversation_id=uuid4(),
+        tokens_used=123,
+        latency_ms=100,
+    )

--- a/src/api/v1/routers/coach.py
+++ b/src/api/v1/routers/coach.py
@@ -2,22 +2,38 @@
 Conversational AI coach (Bedrock Haiku-backed, stateful chat via conversation_id).
 For habit-AI advice see ai.py."""
 
-from uuid import uuid4
+from typing import Annotated
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from config import settings
-from src.core.schemas import CoachReply, CoachRequest, CoachResponse
+from src.api.v1.routers.dependencies import get_ai_coach_service, get_habit_manager
+from src.core.habit_async import AsyncHabitManager
+from src.core.schemas import CoachRequest, CoachResponse
+from src.infrastructure.ai.ai_coach import AICoachService
 
 router = APIRouter(prefix=f"{settings.API_V1_STR}/coach", tags=["coach", "chat"])
 
 
 @router.post("/chat")
-async def chat(request: CoachRequest) -> CoachResponse:
+async def chat(
+    request: CoachRequest,
+    ai_coach: Annotated[AICoachService, Depends(get_ai_coach_service)],
+    habit_manager: Annotated[AsyncHabitManager, Depends(get_habit_manager)],
+) -> CoachResponse:
     """Endpoint for conversational AI coaching interactions."""
+    # return CoachResponse(
+    #     reply=CoachReply(reasoning="LLM reasoning", intent="advice", reply="LLM reply", next_action="none"),
+    #     conversation_id=uuid4(),
+    #     tokens_used=123,
+    #     latency_ms=100,
+    # )
+    # HOw to pass streak habits and at risk to the LLM?
+    async with ai_coach as coach:
+        await coach.converse(request.message, "some context")
     return CoachResponse(
-        reply=CoachReply(reasoning="LLM reasoning", intent="advice", reply="LLM reply", next_action="none"),
-        conversation_id=uuid4(),
+        reply=coach.converse(request.message, "some context"),
+        conversation_id="some_conversation_id",
         tokens_used=123,
         latency_ms=100,
     )

--- a/src/api/v1/routers/coach.py
+++ b/src/api/v1/routers/coach.py
@@ -2,14 +2,16 @@
 Conversational AI coach (Bedrock Haiku-backed, stateful chat via conversation_id).
 For habit-AI advice see ai.py."""
 
+import asyncio
 from typing import Annotated
+from uuid import uuid4
 
 from fastapi import APIRouter, Depends
 
 from config import settings
-from src.api.v1.routers.dependencies import get_ai_coach_service, get_habit_manager
+from src.api.v1.routers.dependencies import get_ai_coach_service, get_current_active_user, get_habit_manager
 from src.core.habit_async import AsyncHabitManager
-from src.core.schemas import CoachRequest, CoachResponse
+from src.core.schemas import CoachContext, CoachRequest, CoachResponse, User
 from src.infrastructure.ai.ai_coach import AICoachService
 
 router = APIRouter(prefix=f"{settings.API_V1_STR}/coach", tags=["coach", "chat"])
@@ -20,20 +22,21 @@ async def chat(
     request: CoachRequest,
     ai_coach: Annotated[AICoachService, Depends(get_ai_coach_service)],
     habit_manager: Annotated[AsyncHabitManager, Depends(get_habit_manager)],
+    current_user: Annotated[User, Depends(get_current_active_user)],
 ) -> CoachResponse:
     """Endpoint for conversational AI coaching interactions."""
-    # return CoachResponse(
-    #     reply=CoachReply(reasoning="LLM reasoning", intent="advice", reply="LLM reply", next_action="none"),
-    #     conversation_id=uuid4(),
-    #     tokens_used=123,
-    #     latency_ms=100,
-    # )
-    # HOw to pass streak habits and at risk to the LLM?
+
+    at_risk = await habit_manager.get_at_risk_habits(current_user.user_id)
+    at_risk = at_risk[:5]
+    analytics = await asyncio.gather(*(habit_manager.get_habit_analytics(h.id) for h in at_risk))
+
+    analytics_by_id = {h.id: a for h, a in zip(at_risk, analytics, strict=True)}
+    context = CoachContext.from_at_risk(at_risk, analytics_by_id)
     async with ai_coach as coach:
-        await coach.converse(request.message, "some context")
+        result = await coach.converse(request.message, context)
     return CoachResponse(
-        reply=coach.converse(request.message, "some context"),
-        conversation_id="some_conversation_id",
-        tokens_used=123,
-        latency_ms=100,
+        reply=result.reply,
+        conversation_id=request.conversation_id or uuid4(),
+        tokens_used=result.tokens_used,
+        latency_ms=result.latency_ms,
     )

--- a/src/api/v1/routers/coach.py
+++ b/src/api/v1/routers/coach.py
@@ -6,7 +6,8 @@ import asyncio
 from typing import Annotated
 from uuid import uuid4
 
-from fastapi import APIRouter, Depends
+from botocore.exceptions import ClientError
+from fastapi import APIRouter, Depends, HTTPException
 
 from config import settings
 from src.api.v1.routers.dependencies import get_ai_coach_service, get_current_active_user, get_habit_manager
@@ -32,8 +33,14 @@ async def chat(
 
     analytics_by_id = {h.id: a for h, a in zip(at_risk, analytics, strict=True)}
     context = CoachContext.from_at_risk(at_risk, analytics_by_id)
-    async with ai_coach as coach:
-        result = await coach.converse(request.message, context)
+    try:
+        async with ai_coach as coach:
+            result = await coach.converse(request.message, context)
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        if code in ("ThrottlingException", "TooManyRequestsException"):
+            raise HTTPException(429, "coach busy, retry shortly") from e
+        raise HTTPException(503, "coach unavailable") from e
     return CoachResponse(
         reply=result.reply,
         conversation_id=request.conversation_id or uuid4(),

--- a/src/api/v1/routers/dependencies.py
+++ b/src/api/v1/routers/dependencies.py
@@ -15,6 +15,7 @@ from src.core.models import UserBase
 from src.core.schemas import TokenData, User, UserInDB, UserWithRole
 from src.core.security import decode_token, verify_password
 from src.infrastructure.ai.ai_client import OllamaClient
+from src.infrastructure.ai.ai_coach import AICoachService
 from src.infrastructure.aws.aws_helper import AWSSessionManager
 from src.infrastructure.aws.email_client import SESClient
 from src.infrastructure.aws.queue_client import SQSClient
@@ -175,3 +176,8 @@ async def get_ollama_client() -> OllamaClient:
 async def get_ai_service() -> HabitContextService:
     """Returns an instance of HabitContextService for dependency injection."""
     return HabitContextService(habit_repo=await get_habit_repository(), user_repo=await get_user_repository())
+
+
+async def get_ai_coach_service() -> AICoachService:
+    """Returns an instance of AICoachService for dependency injection"""
+    return AICoachService()

--- a/src/api/v1/routers/dependencies.py
+++ b/src/api/v1/routers/dependencies.py
@@ -7,7 +7,7 @@ from fastapi.security import HTTPBearer, OAuth2PasswordBearer
 from jwt.exceptions import InvalidTokenError
 
 from config import settings
-from src.core.ai_service import AIService
+from src.core.ai_service import HabitContextService
 from src.core.db import get_async_engine, get_session_maker
 from src.core.events.handlers import Context
 from src.core.habit_async import AsyncHabitManager, AsyncUserManager
@@ -172,6 +172,6 @@ async def get_ollama_client() -> OllamaClient:
     return OllamaClient()
 
 
-async def get_ai_service() -> AIService:
-    """Returns an instance of AIService for dependency injection."""
-    return AIService(habit_repo=await get_habit_repository(), user_repo=await get_user_repository())
+async def get_ai_service() -> HabitContextService:
+    """Returns an instance of HabitContextService for dependency injection."""
+    return HabitContextService(habit_repo=await get_habit_repository(), user_repo=await get_user_repository())

--- a/src/api/v1/routers/habit_advice.py
+++ b/src/api/v1/routers/habit_advice.py
@@ -1,7 +1,7 @@
-"""AI-related endpoints for the Habit Tracker API. This module defines routes that
-interact with the AI service to provide insights and advice on user habits, such as
-identifying at-risk habits and generating personalized coaching advice based on
-user data and habit performance."""
+"""
+Habit-centric AI advice (Ollama-backed, stateless, cached).
+For conversational chat see coach.py.
+"""
 
 import asyncio
 from typing import Annotated, Any
@@ -16,14 +16,14 @@ from src.api.v1.routers.dependencies import (
     get_ollama_client,
     get_redis_manager,
 )
-from src.core.ai_service import AIService
+from src.core.ai_service import HabitContextService
 from src.core.cache import RedisManager
 from src.core.habit_async import AsyncHabitManager
 from src.core.schemas import HabitResponse, User
 from src.infrastructure.ai.ai_client import OllamaClient
 from src.utils.decorators import cache_result, timer
 
-router = APIRouter(prefix=f"{settings.API_V1_STR}/ai", tags=["ai", "habits"])
+router = APIRouter(prefix=f"{settings.API_V1_STR}/habit-advice", tags=["habit-advice", "habits"])
 
 
 @router.get("/advice")
@@ -31,7 +31,7 @@ router = APIRouter(prefix=f"{settings.API_V1_STR}/ai", tags=["ai", "habits"])
 @cache_result(ttl=3600, prefix="ai_general_advice")
 async def get_ai_advice(
     current_user: Annotated[User, Depends(get_current_active_user)],
-    ai_service: Annotated[AIService, Depends(get_ai_service)],
+    ai_service: Annotated[HabitContextService, Depends(get_ai_service)],
     ollama_client: Annotated[OllamaClient, Depends(get_ollama_client)],
     redis_cache: Annotated[RedisManager, Depends(get_redis_manager)],
 ) -> dict[str, Any]:

--- a/src/core/ai_service.py
+++ b/src/core/ai_service.py
@@ -14,7 +14,7 @@ from src.utils.logger import setup_logger
 logger = setup_logger(__name__)
 
 
-class AIService:
+class HabitContextService:
     """Service for fetching data for the AI model."""
 
     def __init__(self, user_repo: UserRepository, habit_repo: HabitRepository):

--- a/src/core/db.py
+++ b/src/core/db.py
@@ -48,7 +48,6 @@ def get_async_engine() -> AsyncEngine:
     engine = create_async_engine(
         DATABASE_ASYNC_URL,
         echo=False,
-        poolclass=NullPool,
         connect_args=connect_args,
     )
 

--- a/src/core/db.py
+++ b/src/core/db.py
@@ -48,6 +48,7 @@ def get_async_engine() -> AsyncEngine:
     engine = create_async_engine(
         DATABASE_ASYNC_URL,
         echo=False,
+        poolclass=NullPool,
         connect_args=connect_args,
     )
 

--- a/src/core/schemas.py
+++ b/src/core/schemas.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Sequence
 from datetime import datetime
-from typing import overload
+from typing import Literal, overload
 from uuid import UUID
 
 from pydantic import (
@@ -242,3 +242,30 @@ class HabitAdvice(BaseModel):
             except ValueError:
                 return 2
         return 2
+
+
+class CoachRequest(BaseModel):
+    """User message to habit coach."""
+
+    message: str = Field(..., min_length=1, max_length=2000, description="User question or update")
+    conversation_id: UUID | None = Field(None, description="Continue thread if set, else new conversation")
+
+
+class CoachReply(BaseModel):
+    """LLM-structured coach output. Field order matters: reasoning -> intent -> reply."""
+
+    reasoning: str = Field(..., description="Why coach chose this reply (chain-of-thought)")
+    intent: Literal["encourage", "advice", "question", "unknown"] = Field(
+        ..., description="Coach act category; 'unknown' if unclear"
+    )
+    reply: str = Field(..., min_length=1, max_length=1000, description="User-facing message")
+    next_action: Literal["await_user", "suggest_habit", "log_completion", "none"] = Field(...)
+
+
+class CoachResponse(BaseModel):
+    """API envelope: LLM output + server telemetry."""
+
+    reply: CoachReply
+    conversation_id: UUID
+    tokens_used: int
+    latency_ms: int

--- a/src/core/schemas.py
+++ b/src/core/schemas.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Sequence
 from datetime import datetime
-from typing import Literal, overload
+from typing import Any, Literal, overload
 from uuid import UUID
 
 from pydantic import (
@@ -269,3 +269,37 @@ class CoachResponse(BaseModel):
     conversation_id: UUID
     tokens_used: int
     latency_ms: int
+
+
+class HabitRiskItem(BaseModel):
+    name: str
+    frequency: str
+    streak: int
+    days_missed: int
+
+
+class CoachContext(BaseModel):
+    """Grounding facts handed to the coach. Deterministic — computed, not LLM-deduced."""
+
+    at_risk: list[HabitRiskItem]
+
+    @classmethod
+    def from_at_risk(
+        cls,
+        habits: list[HabitResponse],
+        analytics_by_id: dict[UUID, dict[str, Any]],
+    ) -> "CoachContext":
+        items = []
+        for habit in habits:
+            a = analytics_by_id.get(habit.id)
+            if a is None:
+                continue
+            items.append(
+                HabitRiskItem(
+                    name=habit.name,
+                    frequency=habit.frequency,
+                    streak=a["streak"],
+                    days_missed=a["days_missed"],
+                )
+            )
+        return cls(at_risk=items)

--- a/src/infrastructure/ai/ai_coach.py
+++ b/src/infrastructure/ai/ai_coach.py
@@ -1,0 +1,98 @@
+import asyncio
+from typing import Any
+
+from aioboto3.session import Session
+from types_aiobotocore_bedrock.client import BedrockClient
+
+from config import settings
+from src.core.schemas import CoachReply
+from src.utils.logger import setup_logger
+
+logger = setup_logger(__name__)
+
+
+class AICoachService:
+    """Bedrock LLM implementation for AI coaching"""
+
+    def __init__(self, model: str = settings.AWS_BEDROCK_LLM_MODEL_ID) -> None:
+        """Initialization of the AICoachService"""
+        self.model: str = model
+        self.session = Session(region_name=settings.AWS_REGION)
+        self.client: BedrockClient | None = None
+
+    async def __aenter__(self) -> "AICoachService":
+        """Initializes the BedrockClient"""
+        logger.debug("Initializing BedrockClient connection.")
+        if self.session is None:
+            self.session = Session()
+        if self.client is None:
+            self._cm = self.session.client("bedrock-runtime")
+            self.client = await self._cm.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type: type[BaseException] | None, exc: BaseException | None, tb: Any) -> None:
+        """Closes the BedrockClient connection"""
+        logger.debug("Closing BedrockClient connection.")
+        if self.client:
+            await self.client.__aexit__(exc_type, exc, tb)
+            self.client = None
+
+    async def converse(self, user_message: str, user_habit_context: str) -> CoachReply:
+        """
+        LLM query to trigger coaching advice based on habit context
+        user_message: Message provided by the user
+        user_habit_context: Habit streaks, missed habits - related to the user.
+        This can be obtained via AsyncHabitManager methods.
+        """
+        if self.client is None:
+            raise RuntimeError("client not initialized — use 'async with'")
+        conversation = [
+            {"role": "user", "content": [{"text": user_message}]},
+        ]
+        system = [
+            {
+                "text": f"You are a habit coach mentor. Your task is to provide user"
+                f"feedback based on the user habit context: {user_habit_context}"
+            }
+        ]
+
+        response = await self.client.converse(
+            modelId=self.model,
+            messages=conversation,
+            system=system,
+            inferenceConfig={
+                "maxTokens": 512,
+                "temperature": 0.5,
+            },
+            toolConfig={
+                "tools": [
+                    {
+                        "toolSpec": {
+                            "name": "coach_reply",
+                            "description": "emit a structured coach reply",
+                            "inputSchema": {"json": CoachReply.model_json_schema()},
+                        }
+                    }
+                ],
+                "toolChoice": {"tool": {"name": "coach_reply"}},
+            },
+        )
+        content = response["output"]["message"]["content"]
+        for elem in content:
+            if "toolUse" in elem:
+                coach_reply = CoachReply.model_validate(elem["toolUse"]["input"])
+        if coach_reply is None:
+            raise RuntimeError(f"expected tool call, got stopReason={response['stopReason']}")
+        logger.info(f"LLM response text: {coach_reply}")
+        return coach_reply
+
+
+async def main() -> None:
+    async with AICoachService() as coach:
+        await coach.converse(
+            user_message="Im struggling with my habits, can you help me?", user_habit_context="Some context"
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/infrastructure/ai/ai_coach.py
+++ b/src/infrastructure/ai/ai_coach.py
@@ -1,14 +1,22 @@
-import asyncio
+import time
+from dataclasses import dataclass
 from typing import Any
 
 from aioboto3.session import Session
 from types_aiobotocore_bedrock.client import BedrockClient
 
 from config import settings
-from src.core.schemas import CoachReply
+from src.core.schemas import CoachContext, CoachReply
 from src.utils.logger import setup_logger
 
 logger = setup_logger(__name__)
+
+
+@dataclass
+class CoachResult:
+    reply: CoachReply
+    tokens_used: int
+    latency_ms: int
 
 
 class AICoachService:
@@ -37,7 +45,7 @@ class AICoachService:
             await self.client.__aexit__(exc_type, exc, tb)
             self.client = None
 
-    async def converse(self, user_message: str, user_habit_context: str) -> CoachReply:
+    async def converse(self, user_message: str, user_habit_context: CoachContext) -> CoachResult:
         """
         LLM query to trigger coaching advice based on habit context
         user_message: Message provided by the user
@@ -55,7 +63,7 @@ class AICoachService:
                 f"feedback based on the user habit context: {user_habit_context}"
             }
         ]
-
+        start = time.perf_counter()
         response = await self.client.converse(
             modelId=self.model,
             messages=conversation,
@@ -77,6 +85,8 @@ class AICoachService:
                 "toolChoice": {"tool": {"name": "coach_reply"}},
             },
         )
+        latency_ms = int((time.perf_counter() - start) * 1000)
+        tokens_used = response["usage"]["totalTokens"]
         content = response["output"]["message"]["content"]
         for elem in content:
             if "toolUse" in elem:
@@ -84,15 +94,4 @@ class AICoachService:
         if coach_reply is None:
             raise RuntimeError(f"expected tool call, got stopReason={response['stopReason']}")
         logger.info(f"LLM response text: {coach_reply}")
-        return coach_reply
-
-
-async def main() -> None:
-    async with AICoachService() as coach:
-        await coach.converse(
-            user_message="Im struggling with my habits, can you help me?", user_habit_context="Some context"
-        )
-
-
-if __name__ == "__main__":
-    asyncio.run(main())
+        return CoachResult(reply=coach_reply, tokens_used=tokens_used, latency_ms=latency_ms)

--- a/tests/test_ai_coach.py
+++ b/tests/test_ai_coach.py
@@ -1,0 +1,63 @@
+import pytest
+from botocore.exceptions import ClientError
+
+from config import settings
+from src.api.main import app
+from src.api.v1.routers.dependencies import get_ai_coach_service
+from src.core.schemas import CoachContext, CoachReply, CoachResponse
+from src.infrastructure.ai.ai_coach import AICoachService, CoachResult
+
+
+class FakeAICoachService(AICoachService):
+    def __init__(self, *, raises: Exception | None = None) -> None:
+        self._raises = raises
+
+    async def __aenter__(self) -> "FakeAICoachService":
+        return self
+
+    async def __aexit__(self, *a) -> None:
+        pass
+
+    async def converse(self, msg, ctx) -> CoachResult:
+        self.received_msg = msg
+        self.received_ctx = ctx
+        if self._raises:
+            raise self._raises
+        else:
+            return CoachResult(
+                reply=CoachReply(
+                    reasoning="Keep going!",
+                    intent="encourage",
+                    reply="Try morning workouts.",
+                    next_action="suggest_habit",
+                ),
+                tokens_used=123,
+                latency_ms=100,
+            )
+
+
+@pytest.mark.integration
+def test_coach_chat_happy(authenticated_as_user_api_client):
+    client = authenticated_as_user_api_client
+    fake = FakeAICoachService()
+    app.dependency_overrides[get_ai_coach_service] = lambda: fake
+    resp = client.post(f"{settings.API_V1_STR}/coach/chat", json={"message": "I missed 3 workouts"})
+
+    assert resp.status_code == 200
+    assert CoachResponse.model_validate(resp.json())
+    assert resp.json()["reply"]["intent"] == "encourage"
+    assert resp.json()["tokens_used"] == 123
+    assert fake.received_msg == "I missed 3 workouts"
+    assert isinstance(fake.received_ctx, CoachContext)
+
+
+@pytest.mark.integration
+def test_coach_chat_throttled(authenticated_as_user_api_client):
+    client = authenticated_as_user_api_client
+    fake = FakeAICoachService(
+        raises=ClientError({"Error": {"Code": "ThrottlingException", "Message": "slow"}}, "Converse")
+    )
+    app.dependency_overrides[get_ai_coach_service] = lambda: fake
+
+    resp = client.post(f"{settings.API_V1_STR}/coach/chat", json={"message": "hi"})
+    assert resp.status_code == 429

--- a/tests/test_ai_service.py
+++ b/tests/test_ai_service.py
@@ -1,4 +1,4 @@
-"""Unit test for AIService modules"""
+"""Unit test for HabitContextService modules"""
 
 from datetime import datetime
 from unittest.mock import AsyncMock
@@ -6,7 +6,7 @@ from uuid import UUID
 
 import pytest
 
-from src.core.ai_service import AIService
+from src.core.ai_service import HabitContextService
 from src.core.exceptions import DatabaseException
 from src.core.models import HabitBase, UserBase
 
@@ -44,7 +44,7 @@ from src.core.models import HabitBase, UserBase
 )
 @pytest.mark.asyncio
 async def test_get_user_context_user_and_habit_data_returned_correctly(
-    ai_service: AIService, habit_data: HabitBase, user_data: UserBase
+    ai_service: HabitContextService, habit_data: HabitBase, user_data: UserBase
 ) -> None:
     """Test that get_user_context returns the correct user and habit data."""
     ai_service.user_repo.get_by_id = AsyncMock(return_value=user_data)
@@ -58,7 +58,7 @@ async def test_get_user_context_user_and_habit_data_returned_correctly(
 
 
 @pytest.mark.asyncio
-async def test_get_user_context_exception_raised_by_repo(ai_service: AIService) -> None:
+async def test_get_user_context_exception_raised_by_repo(ai_service: HabitContextService) -> None:
     """Test that get_user_context propagates exceptions from the habit repository."""
     user_data = UserBase(
         user_id=UUID("00000000-0000-0000-0000-000000000001"),

--- a/tests/test_ai_service_pbt.py
+++ b/tests/test_ai_service_pbt.py
@@ -1,4 +1,4 @@
-"""Unit test for AIService modules using property-based testing"""
+"""Unit test for HabitContextService modules using property-based testing"""
 
 from collections.abc import Callable
 
@@ -6,7 +6,7 @@ import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
-from src.core.ai_service import AIService
+from src.core.ai_service import HabitContextService
 from src.core.models import HabitBase, UserBase
 
 
@@ -17,13 +17,13 @@ from src.core.models import HabitBase, UserBase
 )
 @pytest.mark.asyncio
 async def test_get_user_context_pb(
-    ai_service_factory: Callable[[], AIService], user_entity: UserBase, habits: list[HabitBase]
+    ai_service_factory: Callable[[], HabitContextService], user_entity: UserBase, habits: list[HabitBase]
 ) -> None:
     """
     Test get_user_context with property-based testing to ensure it
     handles various user IDs correctly.
 
-    :ai_service: The AIService instance to test.
+    :ai_service: The HabitContextService instance to test.
     :user_id: A randomly generated UUID to use as the user ID for testing.
     :return: None
     """

--- a/tests/test_cache_key_pbt.py
+++ b/tests/test_cache_key_pbt.py
@@ -1,4 +1,4 @@
-"""Unit test for AIService modules using property-based testing"""
+"""Unit test for HabitContextService modules using property-based testing"""
 
 from uuid import UUID
 

--- a/tests/test_coach_context.py
+++ b/tests/test_coach_context.py
@@ -1,0 +1,35 @@
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+from src.core.schemas import CoachContext, HabitResponse
+
+
+def make_habit(name="Gym", frequency="daily", hid: UUID | None = None) -> HabitResponse:
+    return HabitResponse(
+        id=hid or uuid4(),
+        user_id=uuid4(),
+        name=name,
+        description="x",
+        frequency=frequency,
+        mark_done=False,
+        created_at=datetime.now(UTC),
+    )
+
+
+def test_from_at_risk_maps_fields():
+    h = make_habit(name="Gym", frequency="daily")
+    ctx = CoachContext.from_at_risk([h], {h.id: {"streak": 5, "days_missed": 3}})
+    assert len(ctx.at_risk) == 1
+    item = ctx.at_risk[0]
+    assert (item.name, item.frequency, item.streak, item.days_missed) == ("Gym", "daily", 5, 3)
+
+
+def test_from_at_risk_skips_habit_without_analytics():
+    h1, h2 = make_habit(name="Gym"), make_habit(name="Read")
+    ctx = CoachContext.from_at_risk([h1, h2], {h1.id: {"streak": 1, "days_missed": 4}})
+    assert [i.name for i in ctx.at_risk] == ["Gym"]  # h2 dropped, no fake 0
+
+
+def test_from_at_risk_empty():
+    ctx = CoachContext.from_at_risk([], {})
+    assert ctx.at_risk == []

--- a/uv.lock
+++ b/uv.lock
@@ -925,6 +925,7 @@ dependencies = [
     { name = "redis" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "structlog" },
+    { name = "types-aiobotocore-bedrock" },
     { name = "urllib3" },
     { name = "uvicorn" },
     { name = "weasyprint" },
@@ -972,6 +973,7 @@ requires-dist = [
     { name = "redis", specifier = ">=7.1.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.44" },
     { name = "structlog", specifier = ">=25.5.0" },
+    { name = "types-aiobotocore-bedrock", specifier = ">=3.7.0" },
     { name = "urllib3", specifier = ">=2.6.3" },
     { name = "uvicorn", specifier = ">=0.38.0" },
     { name = "weasyprint", specifier = ">=68.0" },
@@ -2235,6 +2237,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fd/03/6111ed99e9bf7dfa1c30baeef0e0fb7e0bd387bd07f8e5b270776fe1de3f/tinyhtml5-2.0.0.tar.gz", hash = "sha256:086f998833da24c300c414d9fe81d9b368fd04cb9d2596a008421cbc705fcfcc", size = 179507, upload-time = "2024-10-29T15:37:14.078Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/de/27c57899297163a4a84104d5cec0af3b1ac5faf62f44667e506373c6b8ce/tinyhtml5-2.0.0-py3-none-any.whl", hash = "sha256:13683277c5b176d070f82d099d977194b7a1e26815b016114f581a74bbfbf47e", size = 39793, upload-time = "2024-10-29T15:37:11.743Z" },
+]
+
+[[package]]
+name = "types-aiobotocore-bedrock"
+version = "3.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/ac/258ad630310083369269983a5bcac1894a01429b93f4ecc8b7fcbd5b5deb/types_aiobotocore_bedrock-3.7.0.tar.gz", hash = "sha256:4fecf61969302b1f484d91f3621c0cf0e195631a62040bd16ff6b02596e6c317", size = 63974, upload-time = "2026-05-10T03:11:04.183Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/31/33ffe4fde310ff2458fa392f6d342df07ae925cb108451ee7932df05eed0/types_aiobotocore_bedrock-3.7.0-py3-none-any.whl", hash = "sha256:22d994d8561ff15ae451fda9ccd172dec555d72b1ece559feb09e387c3f998e1", size = 72210, upload-time = "2026-05-10T03:11:01.477Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Scaffold AI Coach v1 endpoint stub + restructure existing AI surface for naming clarity.

## Why

- **Coach scaffold:** prerequisite for Thu Bedrock invoke + Fri ship gate (per AI Coach v1 milestone).
- **AIService → HabitContextService rename:** old name was a misnomer (data-fetcher, not LLM client). New name clarifies the boundary vs the incoming Bedrock-backed coach.
- **ai.py → habit_advice.py rename:** disambiguates from new coach.py. Each router now has a single, clear domain.
- **X-Ray asyncpg drop:** unblocks app startup (aws-xray-sdk does not support asyncpg patching).

## Scope

- POST /api/v1/coach/chat — stub returning valid CoachResponse (reply / reasoning / intent / next_action / telemetry). NOT wired to Bedrock yet.
- CoachRequest + CoachReply + CoachResponse added to src/core/schemas.py.
- Router rename + cascade through deps + tests + conftest.
- db.py: drop NullPool from async engine (per-request connect was a perf footgun; pairs with engine memoization).
- .gitignore: ignore local debrief markdown.

## What this does NOT do

- No Bedrock client wiring (Thu Task 1 — depends on #16 Bedrock model access).
- No DDB chat-history persistence (deferred to v1.1 per #21).
- No rate-limit middleware on /coach/chat (per #22, blocker for ship).
- No X-Ray full removal (per #30 — only the asyncpg crash fix).

## Issues

Refs #7 (EPIC), #16, #21, #22, #30.

## Test plan

- [x] App starts cleanly (no X-Ray asyncpg crash)
- [x] POST /api/v1/coach/chat returns 200 + valid CoachResponse JSON
- [x] Existing habit-advice routes still respond on new /habit-advice prefix
- [x] pytest green on renamed test files
- [ ] Bedrock invoke happy path (Thu)
- [ ] Rate-limit applied (per #22)