### PR TITLE
feat(reports): presigned URL download for weekly report PDFs

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -31,6 +31,7 @@ from src.api.v1.routers.dependencies import (
     get_current_active_user,
     get_current_user_with_role,
     get_habit_manager,
+    get_s3_client,
     get_user_manager,
     require_admin,
 )
@@ -51,6 +52,8 @@ from src.core.models import Base, HabitBase, UserBase
 from src.core.schemas import User, UserUpdate, UserWithRole
 from src.core.security import get_password_hash
 from src.infrastructure.ai.ai_client import OllamaClient
+from src.infrastructure.aws.aws_helper import AWSSessionManager
+from src.infrastructure.aws.s3_client import S3Client
 from src.repository.habit_repository import HabitRepository
 from src.repository.user_repository import UserRepository
 
@@ -282,6 +285,12 @@ def mock_require_admin(
 
 
 @pytest.fixture()
+def mocked_s3_client() -> AsyncMock:
+    """Mocked S3 client fixture."""
+    return AsyncMock(spec=S3Client)
+
+
+@pytest.fixture()
 def authenticated_as_user_api_client(
     async_user_manager: AsyncUserManager,
     async_habit_manager: AsyncHabitManager,
@@ -387,15 +396,37 @@ def redis_container() -> Generator[RedisContainer]:
         yield redis
 
 
-# @pytest.fixture(scope="function")
-# def test_lifespan(redis_manager: RedisManager) -> Callable:
-#     """Factory that creates a test lifespan context manager."""
-#     @asynccontextmanager
-#     async def _test_lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
-#         """Test lifespan that uses test Redis."""
-#         app.state.redis_manager = redis_manager
-#         yield
-#     return _test_lifespan
+@pytest.fixture
+def s3_client_and_mock() -> tuple[S3Client, AsyncMock]:
+    mock_session = MagicMock()
+    mock_s3_client = AsyncMock()
+    context_manager = MagicMock()
+    context_manager.__aenter__.return_value = mock_s3_client
+    mock_session.client.return_value = context_manager
+
+    session_manager = MagicMock(spec=AWSSessionManager)
+    session_manager.session = mock_session
+    session_manager.region = "eu-central-1"
+
+    return S3Client(session_manager), mock_s3_client
+
+
+@pytest.fixture()
+def s3_report_api_client(
+    async_user_manager: AsyncUserManager,
+    async_habit_manager: AsyncHabitManager,
+    test_lifespan: Callable[[FastAPI], Any],
+    mock_get_current_active_user: Callable[..., Any],
+    mocked_s3_client: AsyncMock,
+) -> Generator[tuple[TestClient, AsyncMock]]:
+    app.router.lifespan_context = test_lifespan
+    app.dependency_overrides[get_user_manager] = lambda: async_user_manager
+    app.dependency_overrides[get_habit_manager] = lambda: async_habit_manager
+    app.dependency_overrides[get_current_active_user] = mock_get_current_active_user
+    app.dependency_overrides[get_s3_client] = lambda: mocked_s3_client
+    with TestClient(app) as client:
+        yield client, mocked_s3_client
+    app.dependency_overrides.clear()
 
 
 @pytest.fixture()

--- a/src/api/v1/routers/dependencies.py
+++ b/src/api/v1/routers/dependencies.py
@@ -19,6 +19,7 @@ from src.infrastructure.ai.ai_coach import AICoachService
 from src.infrastructure.aws.aws_helper import AWSSessionManager
 from src.infrastructure.aws.email_client import SESClient
 from src.infrastructure.aws.queue_client import SQSClient
+from src.infrastructure.aws.s3_client import S3Client
 from src.repository.habit_repository import HabitRepository
 from src.repository.user_repository import UserRepository
 from src.utils.logger import setup_logger
@@ -181,3 +182,10 @@ async def get_ai_service() -> HabitContextService:
 async def get_ai_coach_service() -> AICoachService:
     """Returns an instance of AICoachService for dependency injection"""
     return AICoachService()
+
+
+async def get_s3_client(
+    aws_session_manager: Annotated[AWSSessionManager, Depends(get_aws_session_manager)],
+) -> S3Client:
+    """Returns an instance of S3Client for dependency injection."""
+    return S3Client(aws_session_manager)

--- a/src/api/v1/routers/reports.py
+++ b/src/api/v1/routers/reports.py
@@ -2,21 +2,23 @@
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, HTTPException, status
 
 from config import settings
 from src.api.v1.routers.dependencies import (
     get_current_active_user,
+    get_s3_client,
     get_sqs_client,
 )
 from src.core.schemas import User
 from src.infrastructure.aws.queue_client import SQSClient
+from src.infrastructure.aws.s3_client import S3Client
 
 router = APIRouter(prefix=f"{settings.API_V1_STR}/reports", tags=["reports"])
 
 
 @router.post("/", status_code=status.HTTP_202_ACCEPTED)
-async def get_habit_report(
+async def send_habit_report(
     current_user: Annotated[User, Depends(get_current_active_user)],
     queue_client: Annotated[SQSClient, Depends(get_sqs_client)],
 ) -> dict[str, str]:
@@ -24,3 +26,23 @@ async def get_habit_report(
     if current_user:
         await queue_client.send_report_trigger(current_user.user_id)
     return {"message": "Report generation started"}
+
+
+@router.get("/{week}/download")
+async def get_habit_report_presigned_url(
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    s3_client: Annotated[S3Client, Depends(get_s3_client)],
+    week: int,
+) -> dict[str, str]:
+    """Generates a presigned URL for downloading the habit report PDF for the given week."""
+    key = f"reports/{current_user.user_id}/weekly_w{week}.pdf"
+    check_url = await s3_client.head_object(settings.AWS_S3_BUCKET_NAME, key)
+    if not check_url:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Report not found. It may still be processing. Please try again later.",
+        )
+    presigned_url = await s3_client.generate_presigned_url(
+        "get_object", {"Bucket": settings.AWS_S3_BUCKET_NAME, "Key": key}, 300
+    )
+    return {"url": presigned_url}

--- a/src/infrastructure/aws/s3_client.py
+++ b/src/infrastructure/aws/s3_client.py
@@ -10,7 +10,6 @@ from src.infrastructure.aws.aws_helper import AWSSessionManager
 from src.utils.logger import setup_logger
 
 logger = setup_logger(__name__)
-DEFAULT_PDF_S3_REPORT_KEY = "reports/weekly-report.pdf"
 
 
 class S3Client:
@@ -119,9 +118,7 @@ class S3Client:
             logger.error(f"Error encountered during getting an object: {e}")
             raise RuntimeError(f"Retrieving object {key} from S3 bucket {bucket_name} not successful") from e
 
-    async def upload_file_to_bucket(
-        self, bucket_name: str, buffer: BytesIO, key: str = DEFAULT_PDF_S3_REPORT_KEY
-    ) -> bool:
+    async def upload_file_to_bucket(self, bucket_name: str, buffer: BytesIO, key: str) -> bool:
         """
         Uploads a file to a bucket. Sets the stream posiiton to 0, to rewind to the
         start of the stream. (after writing to buffer stream position is at the end,
@@ -141,3 +138,49 @@ class S3Client:
         except ClientError as e:
             logger.error(f"Error encountered during uploading file to a bucket: {e}")
             return False
+
+    async def generate_presigned_url(
+        self, client_method: str, method_parameters: dict[str, Any], expires_in: int
+    ) -> Any:
+        """
+        Generates a presigned URL for the given S3 client method and parameters.
+        :client_method: The S3 client method for which to generate the presigned URL
+        (e.g., "get_object", "put_object")
+        :method_parameters: A dictionary of parameters to be passed to the S3 client method
+        (e.g., {"Bucket": ..., "Key": ...})
+        :expires_in: The time in seconds for which the presigned URL is valid
+        Example: await client.generate_presigned_url("get_object", Params={"Bucket": ..., "Key": ...},
+        ExpiresIn=300)
+        """
+        try:
+            logger.info(
+                f"Generating presigned URL for client method: {client_method} with parameters: "
+                f"{method_parameters} and expiration time: {expires_in} seconds"
+            )
+            async with self.session_manager.session.client("s3", region_name=self.session_manager.region) as client:
+                response = await client.generate_presigned_url(
+                    ClientMethod=client_method, Params=method_parameters, ExpiresIn=expires_in
+                )
+            logger.info(f"Got presigned URL: {response}")
+        except ClientError as e:
+            logger.error(f"Couldn't get a presigned URL for client method: {client_method}. Error: {e}")
+            raise
+        return response
+
+    async def head_object(self, bucket_name: str, key: str) -> dict[str, Any]:
+        """Checks if an object exists in the S3 bucket by sending a HEAD request"""
+        try:
+            logger.info(f"Checking if object exists in S3 bucket {bucket_name} using key: {key}")
+            async with self.session_manager.session.client("s3", region_name=self.session_manager.region) as client:
+                response = await client.head_object(
+                    Bucket=bucket_name,
+                    Key=key,
+                )
+            logger.info(f"Response: {response}")
+            return typing.cast(dict[str, Any], response)
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "404":
+                logger.info(f"Object with key {key} not found in bucket {bucket_name}.")
+                return {}
+            logger.error(f"Error encountered during checking if object exists: {e}")
+            raise RuntimeError(f"Checking if object {key} exists in S3 bucket {bucket_name} not successful") from e

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 import pytest
 
+from config import settings
 from src.core.models import HabitBase, HabitCompletion
 from src.infrastructure.pdf.reports_service import ReportService, WeeklyReport
 
@@ -92,3 +93,16 @@ def test_render_html_report(mocked_habit_repository: AsyncMock) -> None:
         assert habit.name in rendered_report
         assert str(habit.total) in rendered_report
         assert habit.status in rendered_report
+
+
+def test_get_report_download_url(s3_report_api_client, async_test_user_sqlite):
+    client, mock_s3 = s3_report_api_client
+    mock_s3.head_object.return_value = {"ContentLength": 1}
+    mock_s3.generate_presigned_url.return_value = "https://url"
+
+    resp = client.get("/api/v1/reports/4/download")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"url": "https://url"}
+    user_id = async_test_user_sqlite["user"].user_id
+    mock_s3.head_object.assert_awaited_once_with(settings.AWS_S3_BUCKET_NAME, f"reports/{user_id}/weekly_w4.pdf")

--- a/tests/test_s3_client.py
+++ b/tests/test_s3_client.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from botocore.exceptions import ClientError
 
 from src.core.models import HabitBase, HabitCompletion
 from src.infrastructure.aws.aws_helper import AWSSessionManager
@@ -81,3 +82,49 @@ async def test_generate_report_and_send_to_s3_bucket(
         mock_s3_client.delete_bucket.return_value = {}
         bucket_deleted = await s3_client.delete_bucket(bucket_name)
         assert bucket_deleted is True
+
+
+@pytest.mark.asyncio
+async def test_generate_presigned_url(s3_client_and_mock) -> None:
+    """
+    Tests the generation of a presigned URL for an S3 object.
+    """
+
+    s3_client, mock_s3_client = s3_client_and_mock
+
+    mock_s3_client.generate_presigned_url.return_value = "https://signed-url"
+
+    presigned_url = await s3_client.generate_presigned_url(
+        client_method="get_object", method_parameters={"Bucket": "test-bucket", "Key": "test-key"}, expires_in=3600
+    )
+    assert presigned_url == "https://signed-url"
+    mock_s3_client.generate_presigned_url.assert_awaited_once_with(
+        ClientMethod="get_object",
+        Params={"Bucket": "test-bucket", "Key": "test-key"},
+        ExpiresIn=3600,
+    )
+
+
+@pytest.mark.asyncio
+async def test_head_object_exists(s3_client_and_mock) -> None:
+    """Tests head_object method for an existing object in the S3 bucket."""
+    s3_client, mock_s3_client = s3_client_and_mock
+    mock_s3_client.head_object.return_value = {"ContentLength": 123, "ContentType": "application/pdf"}
+
+    result = await s3_client.head_object("test-bucket", "test-key")
+
+    assert result == {"ContentLength": 123, "ContentType": "application/pdf"}
+    mock_s3_client.head_object.assert_awaited_once_with(Bucket="test-bucket", Key="test-key")
+
+
+@pytest.mark.asyncio
+async def test_head_object_missing_returns_empty(s3_client_and_mock) -> None:
+    """Tests head_object method for a missing object in the S3 bucket."""
+    s3_client, mock_s3_client = s3_client_and_mock
+    test_bucket, test_key = "test-bucket", "test-key"
+    mock_s3_client.head_object.side_effect = ClientError({"Error": {"Code": "404"}}, "HeadObject")
+
+    result = await s3_client.head_object(test_bucket, test_key)
+
+    assert result == {}
+    mock_s3_client.head_object.assert_awaited_once_with(Bucket=test_bucket, Key=test_key)


### PR DESCRIPTION
  Add GET /reports/{week}/download returning a 5-min presigned S3 URL.
  Key is scoped to the authenticated user (reports/{user_id}/weekly_w{N}.pdf),
  not the path, so a user cannot fetch another user's report. Head-check
  before signing returns 404 when the report is not yet generated.

  - s3_client: add generate_presigned_url and head_object (404 -> {})
  - dependencies: add get_s3_client DI provider
  - tests: unit tests for both S3 methods (mock the AWS client, run the real method, assert_awaited_once_with) + report download endpoint test via dependency_overrides

  Refs #33 (partial: endpoint + presigned method + unit tests + DEFAULT_PDF key cleanup; IAM least-priv, smoke test, docs still open)